### PR TITLE
Add material stock management app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Welcome to Streamlit!
+# Material Stock Manager
 
-Edit `/streamlit_app.py` to customize this app to your heart's desire. :heart:
+This Streamlit app allows you to track materials in stock. You can:
 
-If you have any questions, checkout our [documentation](https://docs.streamlit.io) and [community
-forums](https://discuss.streamlit.io).
+1. Add a material with an initial quantity.
+2. Increase or decrease the quantity of an existing material.
+3. View a table and bar chart showing the current stock levels.
+
+Run the app with `streamlit run streamlit_app.py`.


### PR DESCRIPTION
## Summary
- replace demo with Material Stock Manager example
- document how to run the app

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4260e0648324921c2f227f15452d