### PR TITLE
Restrict materials to dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Material Stock Manager
 
-This Streamlit app allows you to track materials in stock. You can:
+This Streamlit app allows you to track materials in stock. Materials are chosen
+from a small predefined list:
 
-1. Add a material with an initial quantity.
+* Piedra Caliza
+* Durmientes de Madera
+* Malla de Acero
+
+You can:
+
+1. Add a material from the list with an initial quantity.
 2. Increase or decrease the quantity of an existing material.
 3. View a table and bar chart showing the current stock levels.
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,12 +7,18 @@ st.title("Material Stock Manager")
 if 'materials' not in st.session_state:
     st.session_state.materials = {}
 
+MATERIAL_OPTIONS = [
+    "Piedra Caliza",
+    "Durmientes de Madera",
+    "Malla de Acero",
+]
+
 st.header("Add a new material")
 with st.form("add_material"):
-    name = st.text_input("Material name")
+    name = st.selectbox("Material", MATERIAL_OPTIONS)
     qty = st.number_input("Initial quantity", min_value=0, step=1, value=0)
     submitted = st.form_submit_button("Add/Update")
-    if submitted and name:
+    if submitted:
         current = st.session_state.materials.get(name, 0)
         st.session_state.materials[name] = current + int(qty)
 


### PR DESCRIPTION
## Summary
- limit materials to a dropdown of common options
- document the predefined materials in README

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4681f7f883249458d972681b89b4